### PR TITLE
#156225420 enable email functionality and add test for the same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ static/.DS_Store
 hc-venv/
 staticfiles/
 venv/
+
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,4 @@
 web: gunicorn hc.wsgi --log-file -
+release: python manage.py makemigrations --merge && python manage.py migrate
+worker: ./manage.py ensuretriggers && ./manage.py sendreports
+worker: ./manage.py ensuretriggers && ./manage.py sendalerts

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -27,6 +27,7 @@ class LoginTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, 'Log in to healthchecks.io')
         ### Assert contents of the email body
+        self.assertTrue(mail.outbox[0].subject, 'please press the button below:')
 
         ### Assert that check is associated with the new user
         check = Check.objects.filter(user=user).first()

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -120,7 +120,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "http://localhost:8000"
+SITE_ROOT = "http://localhost:8000" # Use local for now. Move to heroku after hosting.
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST
 STATIC_URL = '/static/'
@@ -135,6 +135,14 @@ STATICFILES_FINDERS = (
 COMPRESS_OFFLINE = True
 
 EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
+DJMAIL_REAL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+#Configuring Email
+EMAIL_HOST = os.environ['EMAIL_HOST']
+EMAIL_PORT = os.environ['EMAIL_PORT']
+EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
+EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
+EMAIL_USE_TLS = os.environ['EMAIL_USE_TLS']
 
 # Slack integration -- override these in local_settings
 SLACK_CLIENT_ID = None

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -120,7 +120,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "http://localhost:8000" # Use local for now. Move to heroku after hosting.
+SITE_ROOT = "https://hc-bigas-opus-django-app.herokuapp.com"
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST
 STATIC_URL = '/static/'


### PR DESCRIPTION
**What does this PR do?**

- Add email sending functionality after a user has registered
- Add email notification sending functionality
- Configure tests to confirm email contents

**How should this be manually tested?**

- Clone remote repo to local machine
- Setup project locally and activate the virtual environment
- Run python manage.py test hc.accounts in the terminal

**What are the relevant pivotal tracker stories?**

User should receive email when login link is successfully sent
ID: #156225420