### PR TITLE
#156369159 CHANGING DEFAULT URL DEPENDING ON OS ENV

### DIFF
--- a/hc/settings.py
+++ b/hc/settings.py
@@ -120,7 +120,6 @@ USE_L10N = True
 
 USE_TZ = True
 
-# SITE_ROOT = "https://hc-bigas-opus-django-app.herokuapp.com"
 if os.environ.get("SITE_ROOT") == "HEROKU":
     SITE_ROOT = "https://hc-bigas-opus-django-app.herokuapp.com"
 

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -120,7 +120,13 @@ USE_L10N = True
 
 USE_TZ = True
 
-SITE_ROOT = "https://hc-bigas-opus-django-app.herokuapp.com"
+# SITE_ROOT = "https://hc-bigas-opus-django-app.herokuapp.com"
+if os.environ.get("SITE_ROOT") == "HEROKU":
+    SITE_ROOT = "https://hc-bigas-opus-django-app.herokuapp.com"
+
+if os.environ.get("SITE_ROOT") == "LOCAL":
+    SITE_ROOT = "http://localhost:8000"
+
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST
 STATIC_URL = '/static/'


### PR DESCRIPTION
#### What does this PR do?
Changes the default url depending on the OS environment so that when the email is sent out, it points to the right link
#### How should this be manually tested?
under the configuration setting, one should add the depending on the environment the `SITE_ROOT` to be either `LOCAL`or `HEROKU`.
#### What are the relevant pivotal tracker stories?
#156369159
